### PR TITLE
Bbox query optimize

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+0.0.12
+  - switching type from memory (default) to 'indexed' on bbox queries
+
 0.0.11
   - sorting on _score by default
   - sorting on _score and geo_distance for geo_distance queries

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "geopipes-elasticsearch-backend",
   "author": "mapzen",
-  "version": "0.0.11",
+  "version": "0.0.12",
   "description": "Elasticsearch backend with support for streaming bulk indexing",
   "homepage": "https://github.com/geopipes/elasticsearch-backend",
   "license": "MIT",

--- a/query/geo_bbox.js
+++ b/query/geo_bbox.js
@@ -22,7 +22,8 @@ module.exports = function( centroid, opts ){
 
   var filter = {
     'geo_bounding_box' : {
-      '_cache': true // Speed up duplicate queries. Memory impact?
+      '_cache': true, // Speed up duplicate queries. Memory impact?
+      'type': 'indexed'
     }
   };
 

--- a/test/query-geo-bbox.js
+++ b/test/query-geo-bbox.js
@@ -43,6 +43,7 @@ module.exports.query.generateWithNoCentroid = function(test, common) {
     t.equal(must[0]['geo_bounding_box']['center_point']['right'], '1.00', 'correct geo_bbox right vertice filter value');
     t.equal(must[0]['geo_bounding_box']['center_point']['bottom'], '2.00', 'correct geo_bbox bottom vertice filter value');
     t.equal(must[0]['geo_bounding_box']['center_point']['left'], '2.00', 'correct geo_bbox left vertice filter value');
+    t.equal(must[0]['geo_bounding_box']['_cache'], true, 'query caching enabled');
     t.equal(must[0]['geo_bounding_box']['type'], 'indexed', 'query type set to indexed');
     t.end();
   });

--- a/test/query-geo-bbox.js
+++ b/test/query-geo-bbox.js
@@ -20,7 +20,8 @@ module.exports.query.generate = function(test, common) {
     t.equal(must[0]['geo_bounding_box']['center_point']['right'], '1.00', 'correct geo_bbox right vertice filter value');
     t.equal(must[0]['geo_bounding_box']['center_point']['bottom'], '2.00', 'correct geo_bbox bottom vertice filter value');
     t.equal(must[0]['geo_bounding_box']['center_point']['left'], '2.00', 'correct geo_bbox left vertice filter value');
-    t.equal(must[0]['geo_bounding_box']['_cache'], true, 'query cahing enabled');
+    t.equal(must[0]['geo_bounding_box']['_cache'], true, 'query caching enabled');
+    t.equal(must[0]['geo_bounding_box']['type'], 'indexed', 'query type set to indexed');
     t.end();
   });
 };
@@ -42,7 +43,7 @@ module.exports.query.generateWithNoCentroid = function(test, common) {
     t.equal(must[0]['geo_bounding_box']['center_point']['right'], '1.00', 'correct geo_bbox right vertice filter value');
     t.equal(must[0]['geo_bounding_box']['center_point']['bottom'], '2.00', 'correct geo_bbox bottom vertice filter value');
     t.equal(must[0]['geo_bounding_box']['center_point']['left'], '2.00', 'correct geo_bbox left vertice filter value');
-    t.equal(must[0]['geo_bounding_box']['_cache'], true, 'query cahing enabled');
+    t.equal(must[0]['geo_bounding_box']['type'], 'indexed', 'query type set to indexed');
     t.end();
   });
 };


### PR DESCRIPTION
switching type from memory (default) to 'indexed' on bbox queries
Fixes pelias/api#95
