### PR TITLE
allow overriding sort property

### DIFF
--- a/query/geo_bbox.js
+++ b/query/geo_bbox.js
@@ -14,7 +14,8 @@ module.exports = function( centroid, opts ){
     bottom: Number( opts.bbox.bottom ).toFixed(2),
     left  : Number( opts.bbox.left ).toFixed(2),
     size: opts.size || 1,
-    field: opts.field || 'center_point'
+    field: opts.field || 'center_point',
+    sort: opts.sort || false
   };
 
   var query = baseQuery( centroid, options );

--- a/query/geo_distance.js
+++ b/query/geo_distance.js
@@ -10,7 +10,8 @@ module.exports = function( centroid, opts ){
   var options = {
     distance: opts.distance || '50km',
     size: opts.size || 1,
-    field: opts.field || 'center_point'
+    field: opts.field || 'center_point',
+    sort: opts.sort || false
   };
   var query = baseQuery( centroid, options );
 

--- a/query/geo_shape_point.js
+++ b/query/geo_shape_point.js
@@ -10,7 +10,8 @@ module.exports = function( centroid, opts ){
   var options = {
     relation: opts.relation || 'intersects',
     size: opts.size || 1,
-    field: opts.field || 'boundaries'
+    field: opts.field || 'boundaries',
+    sort: opts.sort || false
   };
 
   var query = baseQuery( centroid, options );

--- a/query/geohash_cell.js
+++ b/query/geohash_cell.js
@@ -10,7 +10,8 @@ module.exports = function( centroid, opts ){
   var options = {
     distance: opts.distance || '50km',
     size: opts.size || 1,
-    field: opts.field || 'center_point'
+    field: opts.field || 'center_point',
+    sort: opts.sort || false
   }
 
   var query = baseQuery( centroid, options );

--- a/test/query-geo-bbox.js
+++ b/test/query-geo-bbox.js
@@ -53,6 +53,21 @@ module.exports.query.generateWithNoCentroid = function(test, common) {
   });
 };
 
+module.exports.query.enableGeoSorting = function(test, common) {
+  test('geo sorting enabled', function(t) {
+    var centroid = { lat: 1, lon: 1 };
+    var bbox = {
+      top   : 1,
+      right : 1,
+      bottom: 2,
+      left  : 2
+    };
+    var q = query(centroid, { bbox: bbox, sort: true });
+    t.equal(q.sort[1]['_geo_distance']['center_point'], centroid, 'correct sort condition');
+    t.end();
+  });
+}
+
 module.exports.all = function (tape, common) {
 
   function test(name, testFunction) {

--- a/test/query-geo-distance.js
+++ b/test/query-geo-distance.js
@@ -19,7 +19,7 @@ module.exports.query.generate = function(test, common) {
 }
 
 module.exports.query.generateWithNoCentroid = function(test, common) {
-  test('generate without centroid', function(t) {
+  test('generate with null centroid', function(t) {
     var centroid = null;
     var q = query(centroid, { distance: '999km' });
     var must = q.query.filtered.filter.bool.must;
@@ -27,6 +27,15 @@ module.exports.query.generateWithNoCentroid = function(test, common) {
     t.equal(Array.isArray(must), true, 'correct bool filter');
     t.equal(must.length, 0, 'no geo_distance filter set');
     t.deepEqual( q.sort, ['_score'], 'should not sort results by distance from centroid' );
+    t.end();
+  });
+}
+
+module.exports.query.enableGeoSorting = function(test, common) {
+  test('geo sorting enabled', function(t) {
+    var centroid = { lat: 1, lon: 1 };
+    var q = query(centroid, { distance: '999km', sort: true });
+    t.equal(q.sort[1]['_geo_distance']['center_point'], centroid, 'correct sort condition');
     t.end();
   });
 }

--- a/test/query-geo-shape-point.js
+++ b/test/query-geo-shape-point.js
@@ -21,6 +21,15 @@ module.exports.query.generate = function(test, common) {
   });
 };
 
+module.exports.query.enableGeoSorting = function(test, common) {
+  test('geo sorting enabled', function(t) {
+    var centroid = { lat: 1.1111, lon: 1.2222 };
+    var q = query(centroid, { distance: '999km', sort: true });
+    t.equal(q.sort[1]['_geo_distance']['center_point'], centroid, 'correct sort condition');
+    t.end();
+  });
+}
+
 module.exports.all = function (tape, common) {
 
   function test(name, testFunction) {

--- a/test/query-geohash-cell.js
+++ b/test/query-geohash-cell.js
@@ -17,6 +17,15 @@ module.exports.query.generate = function(test, common) {
   });
 }
 
+module.exports.query.enableGeoSorting = function(test, common) {
+  test('geo sorting enabled', function(t) {
+    var centroid = { lat: 1.1111, lon: 1.2222 };
+    var q = query(centroid, { distance: '999km', sort: true });
+    t.equal(q.sort[1]['_geo_distance']['center_point'], centroid, 'correct sort condition');
+    t.end();
+  });
+}
+
 module.exports.all = function (tape, common) {
 
   function test(name, testFunction) {


### PR DESCRIPTION
following on from https://github.com/geopipes/elasticsearch-backend/pull/7, this bugfix allows the `sort:true` property to be overridden from any of the queries which implement it.
